### PR TITLE
Use node16 rather than node12

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "install cpm"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
       - name: which cpm
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "install cpm 0.990"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "cpm and a module"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "cpm & modules"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "cpanfile as root"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Create a cpanfile"
         run: |
           echo "requires 'Simple::Accessor';" > cpanfile.test
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "cpanfile non root"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Create a cpanfile"
         run: |
           echo "requires 'Simple::Accessor';" > cpanfile.test
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "install with tests"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
@@ -141,7 +141,7 @@ jobs:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "cpanfile with args"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Create a cpanfile"
         run: |
           echo "requires 'Simple::Accessor';" > cpanfile.test
@@ -184,7 +184,7 @@ jobs:
       - name: perl -V
         run: perl -V
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "install-with-cpm"
 
         uses: ./

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,4 @@
+---
 name: check
 
 on: [push]
@@ -14,7 +15,7 @@ jobs:
 
   cpm:
     runs-on: ubuntu-latest
-    name: "install cpm"
+    name: 'install cpm'
     steps:
       - uses: actions/checkout@v3
       - name: uses install-with-cpm
@@ -26,13 +27,13 @@ jobs:
 
   cpm_version:
     runs-on: ubuntu-latest
-    name: "install cpm 0.990"
+    name: 'install cpm 0.990'
     steps:
       - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
-          version: "0.990"
+          version: '0.990'
       - name: cpm --version
         run: |
           cpm --version
@@ -43,13 +44,13 @@ jobs:
 
   one_module:
     runs-on: ubuntu-latest
-    name: "cpm and a module"
+    name: 'cpm and a module'
     steps:
       - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
-          install: "Simple::Accessor"
+          install: 'Simple::Accessor'
       - run: perl -MSimple::Accessor -e1
 
   ### ------------------------------------------------
@@ -58,7 +59,7 @@ jobs:
 
   multiple_modules:
     runs-on: ubuntu-latest
-    name: "cpm & modules"
+    name: 'cpm & modules'
     steps:
       - uses: actions/checkout@v3
       - name: uses install-with-cpm
@@ -76,33 +77,33 @@ jobs:
 
   cpanfile_root:
     runs-on: ubuntu-latest
-    name: "cpanfile as root"
+    name: 'cpanfile as root'
     steps:
       - uses: actions/checkout@v3
-      - name: "Create a cpanfile"
+      - name: 'Create a cpanfile'
         run: |
           echo "requires 'Simple::Accessor';" > cpanfile.test
       - name: uses install-with-cpm
         uses: ./
         with:
-          cpanfile: "cpanfile.test"
+          cpanfile: 'cpanfile.test'
       - run: perl -MSimple::Accessor -e1
 
   cpanfile_nonroot:
     runs-on: ubuntu-latest
-    name: "cpanfile non root"
+    name: 'cpanfile non root'
     steps:
       - uses: actions/checkout@v3
-      - name: "Create a cpanfile"
+      - name: 'Create a cpanfile'
         run: |
           echo "requires 'Simple::Accessor';" > cpanfile.test
       - name: uses install-with-cpm
         uses: ./
         with:
-          cpanfile: "cpanfile.test"
+          cpanfile: 'cpanfile.test'
           sudo: false
           global: false
-          path: "cpm"
+          path: 'cpm'
       - run: sudo perl cpm install -g local::lib
       - run: perl -Mlocal::lib=--no-create,local -MSimple::Accessor -e1
 
@@ -112,13 +113,13 @@ jobs:
 
   with_tests:
     runs-on: ubuntu-latest
-    name: "install with tests"
+    name: 'install with tests'
     steps:
       - uses: actions/checkout@v3
       - name: uses install-with-cpm
         uses: ./
         with:
-          install: "Simple::Accessor"
+          install: 'Simple::Accessor'
           tests: true
 
   ### ------------------------------------------------
@@ -127,14 +128,14 @@ jobs:
 
   perl_tester:
     runs-on: ubuntu-latest
-    name: "perl v${{ matrix.perl-version }}"
+    name: 'perl v${{ matrix.perl-version }}'
 
     strategy:
       fail-fast: false
       matrix:
         perl-version:
-          - "5.30"
-          - "5.28"
+          - '5.30'
+          - '5.28'
           # ...
 
     container:
@@ -160,17 +161,17 @@ jobs:
 
   with_args:
     runs-on: ubuntu-latest
-    name: "cpanfile with args"
+    name: 'cpanfile with args'
     steps:
       - uses: actions/checkout@v3
-      - name: "Create a cpanfile"
+      - name: 'Create a cpanfile'
         run: |
           echo "requires 'Simple::Accessor';" > cpanfile.test
       - name: uses install-with-cpm
         uses: ./
         with:
-          cpanfile: "cpanfile.test"
-          args: "--with-recommends --with-suggests"
+          cpanfile: 'cpanfile.test'
+          args: '--with-recommends --with-suggests'
       - run: perl -MSimple::Accessor -e1
 
   ## ------------------------------------------------
@@ -178,14 +179,14 @@ jobs:
   ## ------------------------------------------------
   windows:
     runs-on: windows-latest
-    name: "windows"
+    name: 'windows'
 
     steps:
       - name: perl -V
         run: perl -V
 
       - uses: actions/checkout@v3
-      - name: "install-with-cpm"
+      - name: 'install-with-cpm'
 
         uses: ./
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -181,11 +181,6 @@ jobs:
     name: "windows"
 
     steps:
-      - name: Set up Perl
-        run: |
-          choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
-
       - name: perl -V
         run: perl -V
 

--- a/action.yml
+++ b/action.yml
@@ -52,5 +52,5 @@ inputs:
     default: "main"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
This fixes:

"Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
perl-actions/install-with-cpm"
