### PR TITLE
Get rid of setting output variable to perl script / logging info

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,16 +31,16 @@ async function install_cpm(install_to) {
   const version = core.getInput("version");
   const url = `https://raw.githubusercontent.com/skaji/cpm/${version}/cpm`;
 
-  core.setOutput(`Get cpm from ${url}`);
+  core.info(`Get cpm from ${url}`);
 
   const cpmScript = await tc.downloadTool(url);
 
-  core.setOutput("cpm", cpmScript);
+  core.info("cpm", cpmScript);
 
-  console.log(`install_to ${install_to}`);
+  core.info(`install_to ${install_to}`);
 
   const platform = os.platform();
-  //console.log(`OS: :${platform}:`);
+  //core.info(`OS: :${platform}:`);
 
   if (platform == "win32") {
     await io.cp(cpmScript, install_to);
@@ -83,7 +83,7 @@ async function do_exec(cmd) {
   const platform = os.platform();
   const bin = sudo && platform != "win32" ? "sudo" : cmd.shift();
 
-  console.log(`do_exec: ${bin}`);
+  core.info(`do_exec: ${bin}`);
 
   await exec.exec(bin, cmd);
 }
@@ -134,7 +134,7 @@ async function run() {
   /* install one ore more modules */
   if (install !== null && install.length) {
     // install one or more modules
-    console.log(`install: ${install}!`);
+    core.info(`install: ${install}!`);
     const list = install.split("\n");
 
     var cmd = [...CMD_install]; /* clone array */
@@ -147,9 +147,9 @@ async function run() {
   /* install from cpanfile */
   if (cpanfile !== null && cpanfile.length) {
     // install one or more modules
-    console.log(`cpanfile: ${cpanfile}!`);
+    core.info(`cpanfile: ${cpanfile}!`);
     const cpanfile_full_path = path.resolve(cpanfile);
-    console.log(`cpanfile: ${cpanfile_full_path}! [resolved]`);
+    core.info(`cpanfile: ${cpanfile_full_path}! [resolved]`);
 
     var cmd = [...CMD_install];
     cmd.push("--cpanfile", cpanfile_full_path);
@@ -160,7 +160,7 @@ async function run() {
 
   /* custom run with args */
   if ( has_run === false && w_args.length ) {
-    console.log(`custom run with args`);
+    core.info(`custom run with args`);
     var cmd = [...CMD_install];
     has_run = true;
     await do_exec(cmd);


### PR DESCRIPTION
switched to using core.info to log instead of console.log