### PR TITLE
Bump the version of node to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,5 +52,5 @@ inputs:
     default: "main"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "install-with-cpm",
   "version": "1.6.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "node_modules/@actions/core": {


### PR DESCRIPTION
Bump the version of node to 20 since actions have deprecated 16 as per image of annotation and the referenced [notification](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

<img width="1184" alt="nodejs-workflow" src="https://github.com/perl-actions/install-with-cpm/assets/313562/caeaaa33-937c-4827-8b8f-da56deaf3cd8">
