### PR TITLE
feat: retry cpm on transient upstream failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,32 @@ snapshot: "cpanfile.snapshot"
 
 Which version/tag of `cpm` to install. Default is 'main' to use the latest version.
 
+### `retries`
+
+Number of additional attempts after a cpm failure. The action wraps the
+cpm invocation in a retry loop so transient upstream failures (for
+example metacpan `599 Internal Exception` / `Connection timed out` from
+`cpan.metacpan.org:443`) do not flake the job.
+
+Default: `2` (so cpm is tried up to 3 times). Set to `0` to disable and
+restore the single-attempt historical behavior.
+
+```yaml
+- uses: perl-actions/install-with-cpm@v2
+  with:
+    cpanfile: "cpanfile"
+    retries: 3
+```
+
+### `retry-wait`
+
+Base delay (in seconds) between retry attempts. Applied with **linear
+backoff** — attempt N waits `retry-wait * N` seconds before the next
+attempt. With the default values (`retries: 2`, `retry-wait: 20`) the
+waits are 20 s, then 40 s.
+
+Default: `20`.
+
 ## Caching
 
 The action caches the downloaded `cpm` script using [`@actions/cache`](https://github.com/actions/toolkit/tree/main/packages/cache)

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,23 @@ inputs:
     required: false
     default: "main"
 
+  retries:
+    description: >
+      Number of additional attempts after a cpm failure. 0 disables the
+      retry loop (single attempt, historical behavior). Intended to
+      absorb transient upstream failures (e.g. metacpan 599 / connection
+      timed out) without flaking the job.
+    required: false
+    default: "2"
+
+  retry-wait:
+    description: >
+      Base delay in seconds between attempts. Applied with linear
+      backoff: attempt N waits retry-wait * N seconds before the next
+      attempt (e.g. 20s, 40s, 60s with the default).
+    required: false
+    default: "20"
+
 outputs:
   cpm-path:
     description: "Absolute path where cpm was installed"

--- a/dist/index.js
+++ b/dist/index.js
@@ -144,6 +144,17 @@ function is_true(b) {
     return false;
 }
 
+function _parse_non_negative_int(raw, fallback) {
+    if (raw === null || raw === undefined || raw === "") return fallback;
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 0) return fallback;
+    return n;
+}
+
+function _sleep_ms(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function do_exec(cmd) {
     const sudo = is_true(core.getInput("sudo"));
     const platform = os.platform();
@@ -151,9 +162,33 @@ async function do_exec(cmd) {
     const bin = sudo && platform != "win32" ? "sudo" : first;
     const args = sudo && platform != "win32" ? cmd : rest;
 
+    const retries = _parse_non_negative_int(core.getInput("retries"), 2);
+    const retry_wait = _parse_non_negative_int(core.getInput("retry-wait"), 20);
+    const max_attempts = retries + 1;
+
     core.info(`do_exec: ${[bin, ...args].join(" ")}`);
 
-    await exec.exec(bin, args);
+    for (let attempt = 1; attempt <= max_attempts; attempt++) {
+        let err;
+        try {
+            await exec.exec(bin, args);
+            return;
+        } catch (e) {
+            err = e;
+        }
+
+        if (attempt === max_attempts) {
+            throw err;
+        }
+
+        const wait_s = retry_wait * attempt;
+        core.warning(
+            `cpm attempt ${attempt}/${max_attempts} failed (${err.message || err}); ` +
+            `retrying in ${wait_s}s...`
+        );
+        // Indirect through module.exports so tests can stub the sleep.
+        await module.exports._sleep_ms(wait_s * 1000);
+    }
 }
 
 async function run() {
@@ -267,6 +302,9 @@ module.exports = {
     cpm_cache_dir,
     is_immutable_ref,
     run,
+    // Exposed for testing
+    _parse_non_negative_int,
+    _sleep_ms,
 };
 
 

--- a/lib.js
+++ b/lib.js
@@ -138,6 +138,17 @@ function is_true(b) {
     return false;
 }
 
+function _parse_non_negative_int(raw, fallback) {
+    if (raw === null || raw === undefined || raw === "") return fallback;
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 0) return fallback;
+    return n;
+}
+
+function _sleep_ms(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function do_exec(cmd) {
     const sudo = is_true(core.getInput("sudo"));
     const platform = os.platform();
@@ -145,9 +156,33 @@ async function do_exec(cmd) {
     const bin = sudo && platform != "win32" ? "sudo" : first;
     const args = sudo && platform != "win32" ? cmd : rest;
 
+    const retries = _parse_non_negative_int(core.getInput("retries"), 2);
+    const retry_wait = _parse_non_negative_int(core.getInput("retry-wait"), 20);
+    const max_attempts = retries + 1;
+
     core.info(`do_exec: ${[bin, ...args].join(" ")}`);
 
-    await exec.exec(bin, args);
+    for (let attempt = 1; attempt <= max_attempts; attempt++) {
+        let err;
+        try {
+            await exec.exec(bin, args);
+            return;
+        } catch (e) {
+            err = e;
+        }
+
+        if (attempt === max_attempts) {
+            throw err;
+        }
+
+        const wait_s = retry_wait * attempt;
+        core.warning(
+            `cpm attempt ${attempt}/${max_attempts} failed (${err.message || err}); ` +
+            `retrying in ${wait_s}s...`
+        );
+        // Indirect through module.exports so tests can stub the sleep.
+        await module.exports._sleep_ms(wait_s * 1000);
+    }
 }
 
 async function run() {
@@ -261,4 +296,7 @@ module.exports = {
     cpm_cache_dir,
     is_immutable_ref,
     run,
+    // Exposed for testing
+    _parse_non_negative_int,
+    _sleep_ms,
 };

--- a/lib.test.js
+++ b/lib.test.js
@@ -1007,6 +1007,121 @@ describe("do_exec mutation", () => {
     });
 });
 
+describe("do_exec retry", () => {
+    // Stub out the real setTimeout-based sleep so tests don't actually wait.
+    let sleep_spy;
+    beforeEach(() => {
+        sleep_spy = jest
+            .spyOn(lib, "_sleep_ms")
+            .mockImplementation(() => Promise.resolve());
+        jest.spyOn(os, "platform").mockReturnValue("linux");
+    });
+    afterEach(() => {
+        sleep_spy.mockRestore();
+    });
+
+    function mockInputs(inputs) {
+        core.getInput.mockImplementation((name) =>
+            inputs[name] !== undefined ? inputs[name] : ""
+        );
+    }
+
+    test("succeeds on first attempt: no retry, no sleep", async () => {
+        mockInputs({ sudo: "false", retries: "2", "retry-wait": "20" });
+        exec.exec.mockResolvedValue(0);
+
+        await lib.do_exec(["/usr/bin/perl", "-e", "1"]);
+
+        expect(exec.exec).toHaveBeenCalledTimes(1);
+        expect(core.warning).not.toHaveBeenCalled();
+    });
+
+    test("retries on transient failure then succeeds", async () => {
+        mockInputs({ sudo: "false", retries: "2", "retry-wait": "20" });
+        exec.exec
+            .mockRejectedValueOnce(new Error("599 Internal Exception"))
+            .mockResolvedValueOnce(0);
+
+        await lib.do_exec(["cpm", "install"]);
+
+        expect(exec.exec).toHaveBeenCalledTimes(2);
+        expect(core.warning).toHaveBeenCalledWith(
+            expect.stringContaining("attempt 1/3")
+        );
+        // Linear backoff on first retry: retry-wait * 1 = 20s
+        expect(lib._sleep_ms).toHaveBeenCalledWith(20 * 1000);
+    });
+
+    test("gives up after max attempts and rethrows last error", async () => {
+        mockInputs({ sudo: "false", retries: "2", "retry-wait": "5" });
+        exec.exec.mockRejectedValue(new Error("connection timed out"));
+
+        await expect(lib.do_exec(["cpm", "install"])).rejects.toThrow(
+            "connection timed out"
+        );
+
+        // retries=2 -> 3 total attempts
+        expect(exec.exec).toHaveBeenCalledTimes(3);
+        // Linear backoff: 5s then 10s
+        expect(lib._sleep_ms).toHaveBeenNthCalledWith(1, 5 * 1000);
+        expect(lib._sleep_ms).toHaveBeenNthCalledWith(2, 10 * 1000);
+    });
+
+    test("retries=0 disables retry loop", async () => {
+        mockInputs({ sudo: "false", retries: "0", "retry-wait": "20" });
+        exec.exec.mockRejectedValue(new Error("boom"));
+
+        await expect(lib.do_exec(["cpm", "install"])).rejects.toThrow("boom");
+
+        expect(exec.exec).toHaveBeenCalledTimes(1);
+        expect(lib._sleep_ms).not.toHaveBeenCalled();
+    });
+
+    test("defaults: retries=2 when input is empty", async () => {
+        mockInputs({ sudo: "false" });
+        exec.exec.mockRejectedValue(new Error("boom"));
+
+        await expect(lib.do_exec(["cpm", "install"])).rejects.toThrow("boom");
+
+        expect(exec.exec).toHaveBeenCalledTimes(3);
+    });
+
+    test("invalid retries input falls back to default", async () => {
+        mockInputs({ sudo: "false", retries: "not-a-number" });
+        exec.exec.mockRejectedValue(new Error("boom"));
+
+        await expect(lib.do_exec(["cpm", "install"])).rejects.toThrow("boom");
+
+        // Falls back to default of 2 retries = 3 attempts
+        expect(exec.exec).toHaveBeenCalledTimes(3);
+    });
+
+    test("negative retries input falls back to default", async () => {
+        mockInputs({ sudo: "false", retries: "-1" });
+        exec.exec.mockRejectedValue(new Error("boom"));
+
+        await expect(lib.do_exec(["cpm", "install"])).rejects.toThrow("boom");
+
+        expect(exec.exec).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe("_parse_non_negative_int", () => {
+    test.each([
+        ["", 2, 2],
+        [null, 2, 2],
+        [undefined, 2, 2],
+        ["0", 2, 0],
+        ["1", 2, 1],
+        ["42", 2, 42],
+        ["-1", 2, 2],
+        ["abc", 2, 2],
+        ["1.5", 2, 1], // parseInt truncates
+    ])("_parse_non_negative_int(%p, %p) = %p", (raw, fallback, expected) => {
+        expect(lib._parse_non_negative_int(raw, fallback)).toBe(expected);
+    });
+});
+
 describe("install_cpm_location with backslash path", () => {
     test("escapes backslashes in path input", async () => {
         core.getInput.mockImplementation((name) => {


### PR DESCRIPTION
Adds two new action inputs, retries (default 2) and retry-wait (default
20 seconds), and wraps do_exec in a retry loop with linear backoff.
With the defaults cpm is invoked up to 3 times, sleeping 20s then 40s
between attempts.

This absorbs the class of CI flakes caused by transient upstream errors
from the CPAN mirror (for example, metacpan returning "599 Internal
Exception / Could not connect to 'cpan.metacpan.org:443': Connection
timed out" mid-install), without requiring every consumer to build
their own retry wrapper. Set retries: 0 to opt back into the
historical single-attempt behavior.

Retry happens around exec.exec, so the final failure is still surfaced
as a job failure rather than silently masked. Each retry logs a
core.warning line ("cpm attempt N/M failed (...); retrying in Ns...")
so flakes are visible in the run log.

The sleep is routed through module.exports._sleep_ms so jest.spyOn can
stub it in tests without needing fake timers. Invalid or negative
values for retries / retry-wait fall back to the defaults rather than
throwing, since these are surface-level GitHub Actions inputs and a
bad value should not hard-fail the install.

Adds unit tests covering first-attempt success, retry-then-succeed,
exhaustion, retries=0 opt-out, default fallback, and invalid input
handling. Regenerates dist/index.js.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
