### PR TITLE
feat: auto-pin cpm to 0.998003 on Perl < 5.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,15 @@ snapshot: "cpanfile.snapshot"
 
 ### `version`
 
-Which version/tag of `cpm` to install. Default is 'main' to use the latest version.
+Which version/tag of `cpm` to install. Default is `main` to use the latest version.
+
+**Compatibility with Perl < 5.24.** cpm v0.999.0 (March 2026) raised its
+minimum Perl version to v5.24 per the Lyon Amendment. When `version`
+resolves to `main` and `checksum` is empty, this action automatically
+detects the resolved Perl interpreter's version and substitutes the
+legacy pin `0.998003` (the last release that runs on older Perls).
+To opt out, set `version` to a specific cpm release/SHA, or supply a
+`checksum`; either disables the auto-pin entirely.
 
 ### `retries`
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ snapshot: "cpanfile.snapshot"
 
 Which version/tag of `cpm` to install. Default is `main` to use the latest version.
 
-**Compatibility with Perl < 5.24.** cpm v0.999.0 (March 2026) raised its
-minimum Perl version to v5.24 per the Lyon Amendment. When `version`
+**Compatibility with Perl < 5.24.** cpm v0.999.0 raised its minimum
+Perl version to v5.24 per the Lyon Amendment. When `version`
 resolves to `main` and `checksum` is empty, this action automatically
 detects the resolved Perl interpreter's version and substitutes the
 legacy pin `0.998003` (the last release that runs on older Perls).

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,11 @@ inputs:
     default: ""
 
   version:
-    description: "Which version to install"
+    description: >
+      Which version of cpm to install. Default 'main' tracks the latest
+      release. On Perl interpreters older than v5.24, the default is
+      automatically replaced by '0.998003' (the last release before cpm
+      raised its minimum to v5.24). Set this input explicitly to override.
     required: false
     default: "main"
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -58,8 +58,7 @@ function _today_utc() {
     return new Date().toISOString().slice(0, 10);
 }
 
-function cpm_cache_key() {
-    const version = core.getInput("version");
+function cpm_cache_key(version) {
     const base = `cpm-script-${version}-${os.platform()}`;
     if (is_immutable_ref(version)) {
         return base;
@@ -74,6 +73,12 @@ function cpm_cache_dir() {
 }
 
 const MAX_RETRY_DELAY_S = 300;
+
+// Last cpm release that runs on Perl < 5.24.
+// cpm v0.999.0+ requires Perl v5.24 per the Lyon Amendment.
+// If you change this, the new value must satisfy VERSION_PATTERN
+// (see lib.js below) AND be recognized as immutable by is_immutable_ref().
+const LEGACY_PERL_CPM_VERSION = "0.998003";
 
 function compute_sha256(filePath) {
     const content = fs.readFileSync(filePath);
@@ -146,7 +151,7 @@ function split_args(input) {
 const VERSION_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 
 async function install_cpm(perl, install_to) {
-    const version = core.getInput("version");
+    const version = await resolve_cpm_version(perl);
     const checksum = core.getInput("checksum");
 
     if (!version || !VERSION_PATTERN.test(version) || version.includes("..")) {
@@ -157,7 +162,7 @@ async function install_cpm(perl, install_to) {
 
     const url = `https://raw.githubusercontent.com/skaji/cpm/${version}/cpm`;
 
-    const cacheKey = cpm_cache_key();
+    const cacheKey = cpm_cache_key(version);
     const cacheDir = cpm_cache_dir();
     const cachedScript = path.join(cacheDir, "cpm");
 
@@ -211,6 +216,52 @@ async function install_cpm(perl, install_to) {
     }
 
     return { path: install_to, cacheHit };
+}
+
+async function perl_supports_modern_cpm(perl) {
+    let out = "";
+    const options = {
+        silent: true,
+        listeners: {
+            stdout: (data) => {
+                out += data.toString();
+            },
+        },
+    };
+
+    // Use exec.exec directly — not do_exec — because we don't want sudo
+    // or the cpm retry loop wrapping a tiny in-process version probe.
+    await exec.exec(perl, ["-e", "print 0+$]"], options);
+
+    const version = parseFloat(out);
+    if (Number.isNaN(version)) {
+        throw new Error(
+            `Could not parse perl version from output: ${JSON.stringify(out)}`
+        );
+    }
+    return version >= 5.024;
+}
+
+async function resolve_cpm_version(perl) {
+    const version = core.getInput("version");
+    const checksum = core.getInput("checksum");
+
+    // Respect any user pin: explicit version or a checksum means "the user
+    // is taking responsibility for compatibility — don't override them."
+    if (version !== "main" || checksum) {
+        return version;
+    }
+
+    if (await perl_supports_modern_cpm(perl)) {
+        return version;
+    }
+
+    core.info(
+        `Detected Perl < 5.24; pinning cpm to ${LEGACY_PERL_CPM_VERSION} ` +
+        `because cpm v0.999.0+ requires Perl v5.24 (Lyon Amendment). ` +
+        `To override, set 'version' to a non-'main' value (any tag, branch, or SHA) or set 'checksum'.`
+    );
+    return LEGACY_PERL_CPM_VERSION;
 }
 
 async function which_perl() {
@@ -414,9 +465,12 @@ module.exports = {
     cpm_cache_dir,
     is_immutable_ref,
     split_args,
+    perl_supports_modern_cpm,
+    resolve_cpm_version,
     run,
     // Exposed for testing
     MAX_RETRY_DELAY_S,
+    LEGACY_PERL_CPM_VERSION,
     _parse_non_negative_int,
     _sleep_ms,
     compute_sha256,

--- a/lib.js
+++ b/lib.js
@@ -145,7 +145,7 @@ function split_args(input) {
 const VERSION_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 
 async function install_cpm(perl, install_to) {
-    const version = core.getInput("version");
+    const version = await resolve_cpm_version(perl);
     const checksum = core.getInput("checksum");
 
     if (!version || !VERSION_PATTERN.test(version) || version.includes("..")) {
@@ -234,6 +234,28 @@ async function perl_supports_modern_cpm(perl) {
         );
     }
     return version >= 5.024;
+}
+
+async function resolve_cpm_version(perl) {
+    const version = core.getInput("version");
+    const checksum = core.getInput("checksum");
+
+    // Respect any user pin: explicit version or a checksum means "the user
+    // is taking responsibility for compatibility — don't override them."
+    if (version !== "main" || checksum) {
+        return version;
+    }
+
+    if (await perl_supports_modern_cpm(perl)) {
+        return version;
+    }
+
+    core.info(
+        `Detected Perl < 5.24; pinning cpm to ${LEGACY_PERL_CPM_VERSION} ` +
+        `because cpm v0.999.0+ requires Perl v5.24 (Lyon Amendment). ` +
+        `Set 'version' or 'checksum' explicitly to override.`
+    );
+    return LEGACY_PERL_CPM_VERSION;
 }
 
 async function which_perl() {
@@ -438,6 +460,7 @@ module.exports = {
     is_immutable_ref,
     split_args,
     perl_supports_modern_cpm,
+    resolve_cpm_version,
     run,
     // Exposed for testing
     MAX_RETRY_DELAY_S,

--- a/lib.js
+++ b/lib.js
@@ -69,6 +69,12 @@ function cpm_cache_dir() {
 
 const MAX_RETRY_DELAY_S = 300;
 
+// Last cpm release that runs on Perl < 5.24.
+// cpm v0.999.0+ requires Perl v5.24 per the Lyon Amendment.
+// If you change this, the new value must satisfy VERSION_PATTERN
+// (see lib.js below) AND be recognized as immutable by is_immutable_ref().
+const LEGACY_PERL_CPM_VERSION = "0.998003";
+
 function compute_sha256(filePath) {
     const content = fs.readFileSync(filePath);
     return crypto.createHash("sha256").update(content).digest("hex");
@@ -205,6 +211,29 @@ async function install_cpm(perl, install_to) {
     }
 
     return { path: install_to, cacheHit };
+}
+
+async function perl_supports_modern_cpm(perl) {
+    let out = "";
+    const options = {
+        listeners: {
+            stdout: (data) => {
+                out += data.toString();
+            },
+        },
+    };
+
+    // Use exec.exec directly — not do_exec — because we don't want sudo
+    // or the cpm retry loop wrapping a tiny in-process version probe.
+    await exec.exec(perl, ["-e", "print 0+$]"], options);
+
+    const version = parseFloat(out);
+    if (Number.isNaN(version)) {
+        throw new Error(
+            `Could not parse perl version from output: ${JSON.stringify(out)}`
+        );
+    }
+    return version >= 5.024;
 }
 
 async function which_perl() {
@@ -408,9 +437,11 @@ module.exports = {
     cpm_cache_dir,
     is_immutable_ref,
     split_args,
+    perl_supports_modern_cpm,
     run,
     // Exposed for testing
     MAX_RETRY_DELAY_S,
+    LEGACY_PERL_CPM_VERSION,
     _parse_non_negative_int,
     _sleep_ms,
     compute_sha256,

--- a/lib.js
+++ b/lib.js
@@ -253,7 +253,7 @@ async function resolve_cpm_version(perl) {
     core.info(
         `Detected Perl < 5.24; pinning cpm to ${LEGACY_PERL_CPM_VERSION} ` +
         `because cpm v0.999.0+ requires Perl v5.24 (Lyon Amendment). ` +
-        `Set 'version' or 'checksum' explicitly to override.`
+        `To override, set 'version' to a non-'main' value (any tag, branch, or SHA) or set 'checksum'.`
     );
     return LEGACY_PERL_CPM_VERSION;
 }

--- a/lib.js
+++ b/lib.js
@@ -216,6 +216,7 @@ async function install_cpm(perl, install_to) {
 async function perl_supports_modern_cpm(perl) {
     let out = "";
     const options = {
+        silent: true,
         listeners: {
             stdout: (data) => {
                 out += data.toString();

--- a/lib.js
+++ b/lib.js
@@ -52,8 +52,7 @@ function _today_utc() {
     return new Date().toISOString().slice(0, 10);
 }
 
-function cpm_cache_key() {
-    const version = core.getInput("version");
+function cpm_cache_key(version) {
     const base = `cpm-script-${version}-${os.platform()}`;
     if (is_immutable_ref(version)) {
         return base;
@@ -157,7 +156,7 @@ async function install_cpm(perl, install_to) {
 
     const url = `https://raw.githubusercontent.com/skaji/cpm/${version}/cpm`;
 
-    const cacheKey = cpm_cache_key();
+    const cacheKey = cpm_cache_key(version);
     const cacheDir = cpm_cache_dir();
     const cachedScript = path.join(cacheDir, "cpm");
 

--- a/lib.test.js
+++ b/lib.test.js
@@ -1634,6 +1634,68 @@ describe("install_cpm_location path injection safety", () => {
     });
 });
 
+describe("perl_supports_modern_cpm", () => {
+    function mockPerlVersionOutput(output) {
+        exec.exec.mockImplementation(async (bin, args, options) => {
+            if (options && options.listeners && options.listeners.stdout) {
+                options.listeners.stdout(Buffer.from(output));
+            }
+            return 0;
+        });
+    }
+
+    test.each([
+        ["5.024000", true],
+        ["5.030001", true],
+        ["5.040000", true],
+        ["5.024", true],
+    ])("returns true for Perl >= 5.24 (%s)", async (output, expected) => {
+        mockPerlVersionOutput(output);
+        await expect(lib.perl_supports_modern_cpm("/usr/bin/perl")).resolves.toBe(expected);
+    });
+
+    test.each([
+        ["5.022004", false],
+        ["5.020003", false],
+        ["5.016003", false],
+        ["5.008008", false],
+    ])("returns false for Perl < 5.24 (%s)", async (output, expected) => {
+        mockPerlVersionOutput(output);
+        await expect(lib.perl_supports_modern_cpm("/usr/bin/perl")).resolves.toBe(expected);
+    });
+
+    test("invokes perl with the resolved binary path, not the literal 'perl'", async () => {
+        mockPerlVersionOutput("5.030000");
+        await lib.perl_supports_modern_cpm("/custom/path/to/perl");
+        expect(exec.exec).toHaveBeenCalledWith(
+            "/custom/path/to/perl",
+            ["-e", "print 0+$]"],
+            expect.any(Object)
+        );
+    });
+
+    test("throws when stdout is unparseable", async () => {
+        mockPerlVersionOutput("not-a-number");
+        await expect(
+            lib.perl_supports_modern_cpm("/usr/bin/perl")
+        ).rejects.toThrow(/could not parse perl version/i);
+    });
+
+    test("throws when stdout is empty", async () => {
+        mockPerlVersionOutput("");
+        await expect(
+            lib.perl_supports_modern_cpm("/usr/bin/perl")
+        ).rejects.toThrow(/could not parse perl version/i);
+    });
+
+    test("propagates execution failure", async () => {
+        exec.exec.mockRejectedValue(new Error("perl: command not found"));
+        await expect(
+            lib.perl_supports_modern_cpm("/usr/bin/perl")
+        ).rejects.toThrow("perl: command not found");
+    });
+});
+
 describe("is_immutable_ref", () => {
     test.each([
         ["0.997014", true],

--- a/lib.test.js
+++ b/lib.test.js
@@ -1719,44 +1719,29 @@ describe("is_immutable_ref", () => {
 
 describe("cpm_cache_key", () => {
     test("immutable ref (semver tag): plain key, no date suffix", () => {
-        core.getInput.mockImplementation((name) => {
-            if (name === "version") return "0.997014";
-            return "";
-        });
         jest.spyOn(os, "platform").mockReturnValue("linux");
-
-        expect(lib.cpm_cache_key()).toBe("cpm-script-0.997014-linux");
+        expect(lib.cpm_cache_key("0.997014")).toBe("cpm-script-0.997014-linux");
     });
 
     test("immutable ref (commit SHA): plain key, no date suffix", () => {
         const sha = "deadbeefcafebabe1234567890abcdef12345678";
-        core.getInput.mockImplementation((name) => {
-            if (name === "version") return sha;
-            return "";
-        });
         jest.spyOn(os, "platform").mockReturnValue("linux");
+        expect(lib.cpm_cache_key(sha)).toBe(`cpm-script-${sha}-linux`);
+    });
 
-        expect(lib.cpm_cache_key()).toBe(`cpm-script-${sha}-linux`);
+    test("legacy pin (0.998003): plain immutable key, no date suffix", () => {
+        jest.spyOn(os, "platform").mockReturnValue("linux");
+        expect(lib.cpm_cache_key("0.998003")).toBe("cpm-script-0.998003-linux");
     });
 
     test("mutable ref (branch): key gets daily UTC date suffix", () => {
-        core.getInput.mockImplementation((name) => {
-            if (name === "version") return "main";
-            return "";
-        });
         jest.spyOn(os, "platform").mockReturnValue("darwin");
-
         const today = new Date().toISOString().slice(0, 10);
-        expect(lib.cpm_cache_key()).toBe(`cpm-script-main-darwin-${today}`);
+        expect(lib.cpm_cache_key("main")).toBe(`cpm-script-main-darwin-${today}`);
     });
 
     test("mutable ref: key changes when day changes", () => {
-        core.getInput.mockImplementation((name) => {
-            if (name === "version") return "main";
-            return "";
-        });
         jest.spyOn(os, "platform").mockReturnValue("linux");
-
         const realDate = Date;
         try {
             global.Date = class extends realDate {
@@ -1768,7 +1753,7 @@ describe("cpm_cache_key", () => {
                     return new realDate("2026-01-15T10:00:00Z").getTime();
                 }
             };
-            const day1 = lib.cpm_cache_key();
+            const day1 = lib.cpm_cache_key("main");
 
             global.Date = class extends realDate {
                 constructor() {
@@ -1779,7 +1764,7 @@ describe("cpm_cache_key", () => {
                     return new realDate("2026-01-16T10:00:00Z").getTime();
                 }
             };
-            const day2 = lib.cpm_cache_key();
+            const day2 = lib.cpm_cache_key("main");
 
             expect(day1).toBe("cpm-script-main-linux-2026-01-15");
             expect(day2).toBe("cpm-script-main-linux-2026-01-16");

--- a/lib.test.js
+++ b/lib.test.js
@@ -18,6 +18,22 @@ const io = require("@actions/io");
 
 const lib = require("./lib");
 
+// Probe-aware exec.exec mock: tests that call install_cpm now also trigger
+// resolve_cpm_version → perl_supports_modern_cpm, which runs `perl -e 'print 0+$]'`.
+// This helper returns a mockImplementation that satisfies that probe and
+// falls through to a no-op (return 0) for everything else.
+function probeAwareExecMock(perlVersion = "5.030000") {
+    return async (bin, args, options) => {
+        if (args && args.length === 2 && args[0] === "-e" && args[1] === "print 0+$]") {
+            if (options && options.listeners && options.listeners.stdout) {
+                options.listeners.stdout(Buffer.from(perlVersion));
+            }
+            return 0;
+        }
+        return 0;
+    };
+}
+
 let readFileSyncSpy;
 beforeEach(() => {
     jest.clearAllMocks();
@@ -180,7 +196,7 @@ describe("install_cpm", () => {
             return "";
         });
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         jest.spyOn(os, "platform").mockReturnValue("linux");
 
         const result = await lib.install_cpm("/usr/bin/perl", "/usr/local/bin/cpm");
@@ -199,7 +215,7 @@ describe("install_cpm", () => {
             return "";
         });
         tc.downloadTool.mockResolvedValue('/tmp/cpm "$pecial');
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         jest.spyOn(os, "platform").mockReturnValue("linux");
 
         await lib.install_cpm("/usr/bin/perl", '/usr/local/bin/"cpm');
@@ -226,6 +242,7 @@ describe("install_cpm", () => {
         });
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
         io.cp.mockResolvedValue();
+        exec.exec.mockImplementation(probeAwareExecMock());
         jest.spyOn(os, "platform").mockReturnValue("win32");
 
         const result = await lib.install_cpm("/usr/bin/perl", "/usr/local/bin/cpm");
@@ -244,6 +261,13 @@ describe("run", () => {
         io.which.mockResolvedValue("/usr/bin/perl");
         tc.downloadTool.mockResolvedValue("/tmp/cpm-script");
         exec.exec.mockImplementation(async (bin, args, options) => {
+            // resolve_cpm_version probe: feed back a modern-Perl version
+            if (args && args.length === 2 && args[0] === "-e" && args[1] === "print 0+$]") {
+                if (options && options.listeners && options.listeners.stdout) {
+                    options.listeners.stdout(Buffer.from("5.030000"));
+                }
+                return 0;
+            }
             // Simulate install_cpm_location stdout
             if (
                 args &&
@@ -1264,7 +1288,7 @@ describe("install_cpm version validation", () => {
             return "";
         });
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         jest.spyOn(os, "platform").mockReturnValue("linux");
 
         await lib.install_cpm("/usr/bin/perl", "/usr/local/bin/cpm");
@@ -1696,6 +1720,103 @@ describe("perl_supports_modern_cpm", () => {
     });
 });
 
+describe("resolve_cpm_version", () => {
+    function mockPerlVersion(output) {
+        exec.exec.mockImplementation(async (bin, args, options) => {
+            if (options && options.listeners && options.listeners.stdout) {
+                options.listeners.stdout(Buffer.from(output));
+            }
+            return 0;
+        });
+    }
+
+    test("returns 'main' on modern Perl with default version and no checksum", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "";
+            return "";
+        });
+        mockPerlVersion("5.030000");
+
+        await expect(
+            lib.resolve_cpm_version("/usr/bin/perl")
+        ).resolves.toBe("main");
+    });
+
+    test("returns LEGACY_PERL_CPM_VERSION on old Perl with default version and no checksum", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "";
+            return "";
+        });
+        mockPerlVersion("5.020003");
+
+        await expect(
+            lib.resolve_cpm_version("/usr/bin/perl")
+        ).resolves.toBe(lib.LEGACY_PERL_CPM_VERSION);
+        expect(lib.LEGACY_PERL_CPM_VERSION).toBe("0.998003");
+    });
+
+    test("returns user version when version is non-default, even on old Perl (probe NOT invoked)", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "0.997014";
+            if (name === "checksum") return "";
+            return "";
+        });
+
+        await expect(
+            lib.resolve_cpm_version("/usr/bin/perl")
+        ).resolves.toBe("0.997014");
+
+        // Probe must not run when version is explicitly pinned
+        expect(exec.exec).not.toHaveBeenCalled();
+    });
+
+    test("returns 'main' when checksum is set, even on old Perl (probe NOT invoked)", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "a".repeat(64);
+            return "";
+        });
+
+        await expect(
+            lib.resolve_cpm_version("/usr/bin/perl")
+        ).resolves.toBe("main");
+
+        // Probe must not run when checksum is set
+        expect(exec.exec).not.toHaveBeenCalled();
+    });
+
+    test("logs an info line when auto-pin fires", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "";
+            return "";
+        });
+        mockPerlVersion("5.020003");
+
+        await lib.resolve_cpm_version("/usr/bin/perl");
+
+        const logs = core.info.mock.calls.map((c) => c[0]).join("\n");
+        expect(logs).toMatch(/perl.*<.*5\.24/i);
+        expect(logs).toContain("0.998003");
+    });
+
+    test("does NOT log auto-pin info when modern Perl is detected", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "";
+            return "";
+        });
+        mockPerlVersion("5.030000");
+
+        await lib.resolve_cpm_version("/usr/bin/perl");
+
+        const logs = core.info.mock.calls.map((c) => c[0]).join("\n");
+        expect(logs).not.toContain("0.998003");
+    });
+});
+
 describe("is_immutable_ref", () => {
     test.each([
         ["0.997014", true],
@@ -1839,7 +1960,7 @@ describe("install_cpm caching", () => {
         });
         cache.restoreCache.mockResolvedValue(undefined);
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         io.cp.mockResolvedValue();
         io.mkdirP.mockResolvedValue();
 
@@ -1860,7 +1981,7 @@ describe("install_cpm caching", () => {
         });
         cache.restoreCache.mockRejectedValue(new Error("cache unavailable"));
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         io.cp.mockResolvedValue();
         io.mkdirP.mockResolvedValue();
 
@@ -1879,7 +2000,7 @@ describe("install_cpm caching", () => {
         cache.restoreCache.mockResolvedValue(undefined);
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
         cache.saveCache.mockRejectedValue(new Error("save failed"));
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         io.cp.mockResolvedValue();
         io.mkdirP.mockResolvedValue();
 
@@ -1957,7 +2078,7 @@ describe("install_cpm checksum integration", () => {
         jest.spyOn(os, "platform").mockReturnValue("linux");
         readFileSyncSpy.mockReturnValue(Buffer.from(SCRIPT_CONTENT));
         tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
-        exec.exec.mockResolvedValue(0);
+        exec.exec.mockImplementation(probeAwareExecMock());
         io.cp.mockResolvedValue();
         io.mkdirP.mockResolvedValue();
     });

--- a/lib.test.js
+++ b/lib.test.js
@@ -2013,6 +2013,61 @@ describe("install_cpm caching", () => {
     });
 });
 
+describe("install_cpm legacy-Perl auto-pin", () => {
+    beforeEach(() => {
+        jest.spyOn(os, "platform").mockReturnValue("linux");
+    });
+
+    test("on Perl 5.20 with default version and no checksum: downloads 0.998003 and caches with immutable key", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "";
+            if (name === "sudo") return "false";
+            return "";
+        });
+        cache.restoreCache.mockResolvedValue(undefined);
+        tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
+        io.cp.mockResolvedValue();
+        io.mkdirP.mockResolvedValue();
+        exec.exec.mockImplementation(probeAwareExecMock("5.020003"));
+
+        await lib.install_cpm("/usr/bin/perl", "/usr/local/bin/cpm");
+
+        expect(tc.downloadTool).toHaveBeenCalledWith(
+            "https://raw.githubusercontent.com/skaji/cpm/0.998003/cpm"
+        );
+        expect(cache.saveCache).toHaveBeenCalledWith(
+            [lib.cpm_cache_dir()],
+            "cpm-script-0.998003-linux"
+        );
+    });
+
+    test("on Perl 5.30 with default version and no checksum: downloads main with mutable cache key", async () => {
+        core.getInput.mockImplementation((name) => {
+            if (name === "version") return "main";
+            if (name === "checksum") return "";
+            if (name === "sudo") return "false";
+            return "";
+        });
+        cache.restoreCache.mockResolvedValue(undefined);
+        tc.downloadTool.mockResolvedValue("/tmp/cpm-downloaded");
+        io.cp.mockResolvedValue();
+        io.mkdirP.mockResolvedValue();
+        exec.exec.mockImplementation(probeAwareExecMock("5.030000"));
+
+        await lib.install_cpm("/usr/bin/perl", "/usr/local/bin/cpm");
+
+        expect(tc.downloadTool).toHaveBeenCalledWith(
+            "https://raw.githubusercontent.com/skaji/cpm/main/cpm"
+        );
+        const today = new Date().toISOString().slice(0, 10);
+        expect(cache.saveCache).toHaveBeenCalledWith(
+            [lib.cpm_cache_dir()],
+            `cpm-script-main-linux-${today}`
+        );
+    });
+});
+
 describe("compute_sha256", () => {
     test("computes correct SHA-256 hex digest", () => {
         const content = "#!/usr/bin/env perl\nprint 'hello cpm';\n";


### PR DESCRIPTION
## Summary

cpm v0.999.0 raised its minimum Perl version to v5.24 per the Lyon Amendment. Workflows that use this action's default `version: main` on Perl 5.20 / 5.22 now download a cpm script that won't run.

This branch makes the action probe the resolved Perl interpreter at runtime and substitute `0.998003` (the last pre-Lyon release) when the user has not opted out via an explicit `version` or `checksum`. Modern Perl is unaffected — the default still resolves to `main`.

- Auto-pin only fires when **all three** are true: `version` resolves to `main`, `checksum` is empty, and `perl -e 'print 0+\$]'` reports `< 5.024`.
- Explicit pins (any non-`main` version, any tag/branch/SHA) and explicit checksums short-circuit before the probe runs — the probe doesn't execute, so no surprise `exec` cost or behavior change for opted-out users.
- The resolved version flows to **both** the cpm download URL and the cache key, so the immutable `0.998003` cache entry is reused across runs.
- A user-facing `core.info` line announces the auto-pin and explains how to override.

### Implementation

- `lib.js`: new `LEGACY_PERL_CPM_VERSION` constant, new `perl_supports_modern_cpm(perl)` helper (uses `exec.exec` directly with `silent: true` to keep the probe out of CI logs), new `resolve_cpm_version(perl)`, and `cpm_cache_key()` refactored to take `version` as a parameter so URL and cache key always agree.
- `lib.test.js`: 14 new tests across three describe blocks (`perl_supports_modern_cpm`, `resolve_cpm_version`, `install_cpm legacy-Perl auto-pin`), plus a shared `probeAwareExecMock()` helper to keep existing `install_cpm` tests valid.
- `action.yml` + `README.md`: input description and a compatibility note documenting the auto-pin and the override paths.
- `dist/index.js`: regenerated.

## Test plan

- [x] `npm test` — 155 / 155 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — `dist/index.js` regenerates idempotently (working tree stays clean)
- [ ] CI green on this PR
- [ ] Manual smoke test on a workflow using Perl 5.20 confirms `0.998003` is downloaded
- [ ] Manual smoke test on a workflow using Perl 5.30 confirms `main` is downloaded (no behavior change)

## Authorship note

This branch was authored end-to-end by Claude (Anthropic, Opus 4.7) under @oalders' direction. The design, implementation, tests, and docs were all produced by the AI; @oalders reviewed and shipped. Each commit carries a `Co-Authored-By: Claude Opus 4.7` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)